### PR TITLE
Make :PyreplSendVisual command accept range for visual selection

### DIFF
--- a/lua/pyrepl/init.lua
+++ b/lua/pyrepl/init.lua
@@ -105,7 +105,8 @@ function M.setup(opts)
     }
 
     for name, callback in pairs(commands) do
-        vim.api.nvim_create_user_command(name, callback, { force = true, nargs = 0 })
+        local range = (name == 'PyreplSendVisual')
+        vim.api.nvim_create_user_command(name, callback, { force = true, nargs = 0, range = range })
     end
 
     vim.api.nvim_create_user_command("PyreplInstall", function(o)


### PR DESCRIPTION
Problem: :PyreplSendVisual does not work as intended. It throws an error
'E481: No range allowed' despite the visual selection.

Solution: Pass { range = true } to opts, onlny for the :PyreplSendVisual
command.
