### PR TITLE
[feat] Per-filetype cell patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,26 @@ vim.keymap.set("n", "<leader>jl", function()
 end)
 ```
 
+### Cell Pattern Options
+
+- `cell_pattern` (string|fun(): string): Lua pattern used as cell separator, or a function that returns a pattern. Default: `"^# %%%%.*$"`
+
+```lua
+require("pyrepl").setup({
+    -- Simple cell pattern: can be a string or a function
+    cell_pattern = "^# %%%%.*$",
+
+    -- Or use a function for custom logic
+    cell_pattern = function()
+        local ft = vim.bo.filetype
+        if ft == "markdown" or ft == "quarto" then
+            return "^```.*$"
+        end
+        return "^# %%%%.*$"
+    end,
+})
+```
+
 ## Commands and API
 
 Commands:

--- a/doc/pyrepl.txt
+++ b/doc/pyrepl.txt
@@ -239,10 +239,23 @@ Options:
       Use "placeholders" for ghostty and kitty terminals.
       Use "image" for other terminals, you should configure `image.nvim`
       plugin.
-  cell_pattern (string)
+  cell_pattern (string|function)
       Lua pattern used as cell separators for |PyreplSendCell|,
       |PyreplStepCellForward| and |PyreplStepCellBackward|.
+      Can be a string pattern or a function that returns a pattern.
       Default: "^# %%%%.*$".
+      Example: >
+        cell_pattern = "^```.*$"
+<
+      Example with function for per-filetype patterns: >
+        cell_pattern = function()
+          local ft = vim.bo.filetype
+          if ft == "markdown" or ft == "quarto" then
+            return "^```.*$"
+          end
+          return "^# %%%%.*$"
+        end
+<
   python_path (string)
       Python interpreter used by pyrepl.nvim. Default: "python".
       Resolution order is: `python_path`, then `g:python3_host_prog`, then

--- a/lua/pyrepl/config.lua
+++ b/lua/pyrepl/config.lua
@@ -66,6 +66,16 @@ function M.get_state()
     return state
 end
 
+---Get the effective cell pattern for the current buffer.
+---@return string
+function M.get_effective_cell_pattern()
+    local pattern = state.cell_pattern
+    if type(pattern) == "function" then
+        return pattern()
+    end
+    return pattern
+end
+
 ---@param opts? pyrepl.ConfigOpts
 function M.update_state(opts)
     state = vim.tbl_deep_extend("force", state, opts or {})

--- a/lua/pyrepl/init.lua
+++ b/lua/pyrepl/init.lua
@@ -73,7 +73,7 @@ function M.send_cell()
     local chan = core.get_chan()
     if chan then
         local idx = vim.api.nvim_win_get_cursor(0)[1]
-        send.send_cell(0, chan, idx, config.get_state().cell_pattern)
+        send.send_cell(0, chan, idx, config.get_effective_cell_pattern())
         core.scroll_repl()
     end
 end

--- a/lua/pyrepl/send.lua
+++ b/lua/pyrepl/send.lua
@@ -216,7 +216,7 @@ end
 function M.step_cell_forward(win)
     local buf = vim.api.nvim_win_get_buf(win)
     local idx = vim.api.nvim_win_get_cursor(win)[1]
-    local _, end_idx = get_cell_range(buf, idx, config.get_state().cell_pattern)
+    local _, end_idx = get_cell_range(buf, idx, config.get_effective_cell_pattern())
 
     if end_idx then
         vim.api.nvim_win_call(win, function()
@@ -230,7 +230,7 @@ function M.step_cell_backward(win)
     local buf = vim.api.nvim_win_get_buf(win)
     local idx = vim.api.nvim_win_get_cursor(win)[1]
     local line = vim.api.nvim_buf_get_lines(buf, idx - 1, idx, false)[1]
-    local cell_pattern = require("pyrepl.config").get_state().cell_pattern
+    local cell_pattern = config.get_effective_cell_pattern()
 
     if line:match(cell_pattern) then
         idx = math.max(1, idx - 1)

--- a/lua/pyrepl/types.lua
+++ b/lua/pyrepl/types.lua
@@ -10,7 +10,7 @@
 ---@field image_width_ratio number
 ---@field image_height_ratio number
 ---@field image_provider string
----@field cell_pattern string
+---@field cell_pattern string|fun(): string
 ---@field python_path string|nil
 ---@field preferred_kernel string|nil
 ---@field jupytext_hook boolean
@@ -25,7 +25,7 @@
 ---@field image_width_ratio? number
 ---@field image_height_ratio? number
 ---@field image_provider? "placeholders" | "image" | string
----@field cell_pattern? string
+---@field cell_pattern? string|fun(): string
 ---@field python_path? string
 ---@field preferred_kernel? string
 ---@field jupytext_hook? boolean


### PR DESCRIPTION
Love the plugin you have created!

One thing that became apparent relatively quickly with my workflow (working sometimes in pure python files, often in a mix of markdown and quarto files) is that a single cell pattern is not enough for me.

I was working with a local buffer override of the cell determination logic in my configuration for a bit, but thought this might be useful for the plugin itself. 

This PR does three things:

1. Adds a new configuration option called `ft_cell_patterns` which is a table mapping vim filetypes to cell pattern strings.
2. Adds a new buffer-local `vim.b.pyrepl_cell_pattern` which will be picked up by the plugin.
3. Introduces a single function which finds the correct cell pattern at any moment, giving precedence to the buffer-local variable > the `ft_cell_patterns` mappings > the global default. That means if nothing is changed previous user configurations work without changes.

It also adds some documentation for this logic (though I am not sure how well the explanations are written).

Let me know if this is a feature that you could see implementing into the plugin - I am also happy to change any aspects you think don't make sense or should work differently.