### PR TITLE
Fix potential race condition with repl_scroll norm invocation

### DIFF
--- a/lua/pyrepl/core.lua
+++ b/lua/pyrepl/core.lua
@@ -166,11 +166,12 @@ end
 
 ---Scroll REPL window to the end so the latest cell is in focus.
 function M.scroll_repl()
-    if state and state.win and vim.api.nvim_win_is_valid(state.win) then
-        vim.api.nvim_win_call(state.win, function()
-            vim.cmd.normal({ "G", bang = true })
-        end)
+    if not (state and state.win and vim.api.nvim_win_is_valid(state.win)) then
+        return
     end
+
+    local nl = vim.api.nvim_buf_line_count(vim.api.nvim_win_get_buf(state.win))
+    vim.api.nvim_win_set_cursor(state.win, { nl, 0 })
 end
 
 ---Toggle REPL terminal focus.


### PR DESCRIPTION
When using this plugin in combination with a `vim.ui.select` replacement such as [`dressing.nvim`](https://github.com/stevearc/dressing.nvim) or [`fzf-lua.nvim`](https://github.com/ibhagwan/fzf-lua),
sometimes on opening a new repl (i.e. the `open_new_repl()` function is called) vim produces an error like the following:

<details>
<summary>
Error produced in combination with fzf-lua:
</summary>

```
fn_selected threw an error: ...y/.local/share/nvim/lazy/pyrepl.nvim/lua/pyrepl/core.lua:170: Error executing lua: ...y/.local/share/nvim/lazy/pyrepl.nvim/lua/pyrepl/cor
e.lua:171: Vim:Can't re-enter normal mode from terminal mode                                                                                                                      
stack traceback:                                                                                                                                                                  
        [C]: in function 'normal'                                                                                                                                                 
        ...y/.local/share/nvim/lazy/pyrepl.nvim/lua/pyrepl/core.lua:171: in function <...y/.local/share/nvim/lazy/pyrepl.nvim/lua/pyrepl/core.lua:170>                            
        [C]: in function 'resume'                                                                                                                                                 
        ...marty/.local/share/nvim/lazy/fzf-lua/lua/fzf-lua/fzf.lua:176: in function <...marty/.local/share/nvim/lazy/fzf-lua/lua/fzf-lua/fzf.lua:163>                            
stack traceback:                                                                                                                                                                  
        [C]: in function 'nvim_win_call'                                                                                                                                          
        ...y/.local/share/nvim/lazy/pyrepl.nvim/lua/pyrepl/core.lua:170: in function 'scroll_repl'                                                                                
        ...y/.local/share/nvim/lazy/pyrepl.nvim/lua/pyrepl/core.lua:164: in function 'open_new_repl'                                                                              
        ...y/.local/share/nvim/lazy/pyrepl.nvim/lua/pyrepl/core.lua:202: in function 'callback'                                                                                   
        ....local/share/nvim/lazy/pyrepl.nvim/lua/pyrepl/python.lua:107: in function '_on_choice'                                                                                 
        ...re/nvim/lazy/fzf-lua/lua/fzf-lua/providers/ui_select.lua:52: in function 'fn'                                                                                          
        ...y/.local/share/nvim/lazy/fzf-lua/lua/fzf-lua/actions.lua:126: in function 'act'                                                                                        
        ...re/nvim/lazy/fzf-lua/lua/fzf-lua/providers/ui_select.lua:126: in function 'exec_choice'                                                                                
        ...re/nvim/lazy/fzf-lua/lua/fzf-lua/providers/ui_select.lua:150: in function 'fn_selected'                                                                                
        ...arty/.local/share/nvim/lazy/fzf-lua/lua/fzf-lua/core.lua:288: in function <...arty/.local/share/nvim/lazy/fzf-lua/lua/fzf-lua/core.lua:278>                            
        [C]: in function 'xpcall'                                                                                                                                                 
        ...arty/.local/share/nvim/lazy/fzf-lua/lua/fzf-lua/core.lua:278: in function <...arty/.local/share/nvim/lazy/fzf-lua/lua/fzf-lua/core.lua:273>
```

</details>

<details>
<summary>
Error produced in combination with dressing.nvim:
</summary>

```
Error executing vim.schedule lua callback: ...y/.local/share/nvim/lazy/pyrepl.nvim/lua/pyrepl/core.lua:170: Error executing lua: ...y/.local/share/nvim/lazy/pyrepl.nvim/lua/pyrep
l/core.lua:171: Vim:Can't re-enter normal mode from terminal mode                                                                                                                 
stack traceback:                                                                                                                                                                  
        [C]: in function 'normal'                                                                                                                                                 
        ...y/.local/share/nvim/lazy/pyrepl.nvim/lua/pyrepl/core.lua:171: in function <...y/.local/share/nvim/lazy/pyrepl.nvim/lua/pyrepl/core.lua:170>                            
        [C]: in function 'nvim_win_call'                                                                                                                                          
        ...y/.local/share/nvim/lazy/pyrepl.nvim/lua/pyrepl/core.lua:170: in function 'scroll_repl'                                                                                
        ...y/.local/share/nvim/lazy/pyrepl.nvim/lua/pyrepl/core.lua:164: in function 'open_new_repl'                                                                              
        ...y/.local/share/nvim/lazy/pyrepl.nvim/lua/pyrepl/core.lua:202: in function 'callback'                                                                                   
        ....local/share/nvim/lazy/pyrepl.nvim/lua/pyrepl/python.lua:107: in function 'cb'                                                                                         
        ...ocal/share/nvim/lazy/dressing.nvim/lua/dressing/util.lua:206: in function <...ocal/share/nvim/lazy/dressing.nvim/lua/dressing/util.lua:202>                            
stack traceback:                                                                                                                                                                  
        [C]: in function 'nvim_win_call'                                                                                                                                          
        ...y/.local/share/nvim/lazy/pyrepl.nvim/lua/pyrepl/core.lua:170: in function 'scroll_repl'                                                                                
        ...y/.local/share/nvim/lazy/pyrepl.nvim/lua/pyrepl/core.lua:164: in function 'open_new_repl'                                                                              
        ...y/.local/share/nvim/lazy/pyrepl.nvim/lua/pyrepl/core.lua:202: in function 'callback'                                                                                   
        ....local/share/nvim/lazy/pyrepl.nvim/lua/pyrepl/python.lua:107: in function 'cb'                                                                                         
        ...ocal/share/nvim/lazy/dressing.nvim/lua/dressing/util.lua:206: in function <...ocal/share/nvim/lazy/dressing.nvim/lua/dressing/util.lua:202>                            
```

</details>

It doesn't seem to occur with [`telescope-ui-select.nvim`](https://github.com/nvim-telescope/telescope-ui-select.nvim) for example,
and I haven't tried more `vim.ui.select` replacements.

To reproduce install the fzf-lua plugin, e.g. with lazy (`{"ibhagwan/fzf-lua", opts = {}}`) and run `:FzfLua register_ui_select` and try to open a new repl. Generally, the first attempt instantly showed the error for me.

The failure does not _always_ occur, and I can't reproduce it completely reliably. But when it appears it always stems from the `scroll_repl` function, more specifically the `:normal G` command call as it seems ':normal' commands still [don't reliably work in terminal mode](https://github.com/neovim/neovim/issues/4895). I believe it may be a race condition between the `vim.ui.select` plugins which use the terminal with this still showing, the repl terminal becoming ready and the `scroll_repl` function call:

- if the terminal is still 'starting up' and while the buffer is opened it hasn't entered 'terminal mode' yet, no error appears.
- if the `vim.ui.select` terminal is still in 'terminal mode' or the repl terminal is fully loaded and we have entered 'terminal mode', the error is produced by the `:normal` command call.

However, for all the findings above the fix itself seems easy:

instead of calling the normal mode through `vim.cmd.normal({ "G", bang = true })`,
just using `vim.api` functionality to set the cursor to the last line always works regardless of any terminal modes.

That's what this PR does to hopefully shield from any other terminal mode interactions.