### PR TITLE
feat: ability to set different cell start/end pattern

### DIFF
--- a/lua/pyrepl/config.lua
+++ b/lua/pyrepl/config.lua
@@ -11,6 +11,7 @@ local defaults = {
     image_height_ratio = 0.5,
     image_provider = "placeholders",
     cell_pattern = "^# %%%%.*$",
+    cell_pattern_end = nil,
     python_path = "python",
     preferred_kernel = "python3",
     jupytext_hook = true,
@@ -67,15 +68,19 @@ function M.get_state()
 end
 
 ---Get the effective cell pattern for the current buffer.
----@return string
+---@return pyrepl.Pattern
 function M.get_cell_pattern()
     local pattern = state.cell_pattern
+    local pattern_end = state.cell_pattern_end
 
     if type(pattern) == "function" then
-        return pattern()
+        pattern = pattern()
+    end
+    if type(pattern_end) == "function" then
+        pattern_end = pattern_end()
     end
 
-    return pattern
+    return { pat_start = pattern, pat_end = pattern_end or pattern }
 end
 
 ---@param opts? pyrepl.ConfigOpts

--- a/lua/pyrepl/send.lua
+++ b/lua/pyrepl/send.lua
@@ -251,7 +251,7 @@ function M.step_cell_backward(win)
 
     local lines = vim.api.nvim_buf_get_lines(buf, 0, start_idx, false)
     local target = nil
-    for i = start_idx - 2, 0, -1 do
+    for i = start_idx - 2, 1, -1 do
         if lines[i]:match(cell_pattern.pat_end) then
             target, _ = get_cell_range(buf, i, cell_pattern)
             break

--- a/lua/pyrepl/send.lua
+++ b/lua/pyrepl/send.lua
@@ -216,11 +216,24 @@ end
 function M.step_cell_forward(win)
     local buf = vim.api.nvim_win_get_buf(win)
     local idx = vim.api.nvim_win_get_cursor(win)[1]
-    local _, end_idx = get_cell_range(buf, idx, config.get_cell_pattern())
+    local cell_pattern = config.get_cell_pattern()
+    local _, end_idx = get_cell_range(buf, idx, cell_pattern)
 
-    if end_idx then
+    -- not in a cell
+    if not end_idx then
+        return
+    end
+    local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+    local target = nil
+    for i = end_idx + 1, #lines do
+        if lines[i]:match(cell_pattern.pat_start) then
+            target, _ = get_cell_range(buf, i, cell_pattern)
+            break
+        end
+    end
+    if target then
         vim.api.nvim_win_call(win, function()
-            vim.cmd.normal({ tostring(end_idx + 1) .. "gg^", bang = true })
+            vim.cmd.normal({ tostring(target) .. "gg^", bang = true })
         end)
     end
 end
@@ -229,20 +242,28 @@ end
 function M.step_cell_backward(win)
     local buf = vim.api.nvim_win_get_buf(win)
     local idx = vim.api.nvim_win_get_cursor(win)[1]
-    local line = vim.api.nvim_buf_get_lines(buf, idx - 1, idx, false)[1]
     local cell_pattern = config.get_cell_pattern()
 
-    if line:match(cell_pattern.pat_start) then
-        idx = math.max(1, idx - 1)
+    local start_idx, _ = get_cell_range(buf, idx, cell_pattern)
+    if not start_idx then
+        return
     end
 
-    local start_idx, _ = get_cell_range(buf, idx, cell_pattern)
+    local lines = vim.api.nvim_buf_get_lines(buf, 0, start_idx, false)
+    local target = nil
+    for i = start_idx - 2, 0, -1 do
+        if lines[i]:match(cell_pattern.pat_end) then
+            target, _ = get_cell_range(buf, i, cell_pattern)
+            break
+        end
+    end
 
-    if start_idx then
+    if target then
         vim.api.nvim_win_call(win, function()
-            vim.cmd.normal({ tostring(math.max(0, start_idx - 1)) .. "gg^", bang = true })
+            vim.cmd.normal({ tostring(math.max(0, target)) .. "gg^", bang = true })
         end)
     end
 end
 
 return M
+

--- a/lua/pyrepl/send.lua
+++ b/lua/pyrepl/send.lua
@@ -145,7 +145,7 @@ end
 
 ---@param buf integer
 ---@param idx integer
----@param cell_pattern string
+---@param cell_pattern pyrepl.Pattern
 ---@return integer|nil
 ---@return integer|nil
 local function get_cell_range(buf, idx, cell_pattern)
@@ -157,7 +157,7 @@ local function get_cell_range(buf, idx, cell_pattern)
     -- block start
     local start_idx = 1
     for i = idx, 1, -1 do
-        if lines[i]:match(cell_pattern) then
+        if lines[i]:match(cell_pattern.pat_start) then
             start_idx = i + 1
             break
         end
@@ -166,7 +166,7 @@ local function get_cell_range(buf, idx, cell_pattern)
     -- block end
     local end_idx = #lines
     for i = idx + 1, #lines do
-        if lines[i]:match(cell_pattern) then
+        if lines[i]:match(cell_pattern.pat_end) then
             end_idx = i - 1
             break
         end
@@ -201,7 +201,7 @@ end
 ---@param buf integer
 ---@param chan integer
 ---@param idx integer
----@param cell_pattern string
+---@param cell_pattern pyrepl.Pattern
 function M.send_cell(buf, chan, idx, cell_pattern)
     local start_idx, end_idx = get_cell_range(buf, idx, cell_pattern)
 
@@ -232,7 +232,7 @@ function M.step_cell_backward(win)
     local line = vim.api.nvim_buf_get_lines(buf, idx - 1, idx, false)[1]
     local cell_pattern = config.get_cell_pattern()
 
-    if line:match(cell_pattern) then
+    if line:match(cell_pattern.pat_start) then
         idx = math.max(1, idx - 1)
     end
 

--- a/lua/pyrepl/types.lua
+++ b/lua/pyrepl/types.lua
@@ -11,6 +11,7 @@
 ---@field image_height_ratio number
 ---@field image_provider string
 ---@field cell_pattern string|fun(): string
+---@field cell_pattern_end? string|fun(): string
 ---@field python_path string|nil
 ---@field preferred_kernel string|nil
 ---@field jupytext_hook boolean
@@ -50,3 +51,7 @@
 ---@field idx integer
 ---@field buf integer|nil
 ---@field win integer|nil
+
+---@class pyrepl.Pattern
+---@field pat_start string 
+---@field pat_end string 


### PR DESCRIPTION
This allows to correctly use markdown, or to ignore text code cells 
```lua
require("pyrepl").setup({
    cell_pattern = function()
        if vim.bo.filetype == "markdown" then
            return "^```python.*$"
        end
        return "^# %%%%.*$"
    end,
    cell_pattern_end = function()
        if vim.bo.filetype == "markdown" then
            return "^```.*$"
        end
        return "^# %%%%.*$"
    end,
    })
```